### PR TITLE
feat: add copy to clipboard button

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -11,14 +11,6 @@ vi.mock("@monaco-editor/react", () => ({
   ),
 }));
 
-// Mock lucide-react icons
-vi.mock("lucide-react", () => ({
-  Sun: () => <div data-testid="sun-icon" />,
-  Moon: () => <div data-testid="moon-icon" />,
-  Menu: () => <div data-testid="menu-icon" />,
-  HelpCircle: () => <div data-testid="help-circle-icon" />,
-}));
-
 // Mock the hooks
 vi.mock("./hooks/useFileUpload", () => ({
   useFileUpload: vi.fn(() => ({
@@ -67,6 +59,10 @@ vi.mock("./components/TreeView", () => ({
       {tree.length > 0 ? "Tree content" : "No tree content"}
     </div>
   ),
+}));
+
+vi.mock("./components/Clipboard", () => ({
+  Clipboard: () => <div data-testid="clipboard" />,
 }));
 
 vi.mock("./components/ErrorBoundary", () => ({

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { Box, Flex, Heading, HStack, IconButton } from "@chakra-ui/react";
 import { Sun, Moon, Menu, HelpCircle } from "lucide-react";
 import MonacoEditor from "@monaco-editor/react";
 import { TreeView } from "./components/TreeView";
+import { Clipboard } from "./components/Clipboard";
 import ErrorBoundary from "./components/ErrorBoundary";
 import { TabsRoot, TabsList, TabsTrigger, TabsContentGroup, TabsContent } from "@chakra-ui/react";
 import { SideDrawer } from "./components/SideDrawer";
@@ -270,9 +271,12 @@ function AppContent() {
                       display="flex"
                       flexDirection="column"
                     >
-                      <Heading size="sm" mb={4} color={darkMode ? 'purple.400' : 'purple.600'}>
-                        GraphQL Schema
-                      </Heading>
+                      <HStack justify="space-between" mb={4}>
+                        <Heading size="sm" color={darkMode ? 'purple.400' : 'purple.600'}>
+                          GraphQL Schema
+                        </Heading>
+                        <Clipboard textToCopy={graphqlSchema} darkMode={darkMode} />
+                      </HStack>
                       <Box
                         borderRadius="md"
                         overflow="auto"
@@ -309,9 +313,12 @@ function AppContent() {
                       display="flex"
                       flexDirection="column"
                     >
-                      <Heading size="sm" mb={4} color={darkMode ? 'purple.400' : 'purple.600'}>
-                        App Config YAML
-                      </Heading>
+                      <HStack justify="space-between" mb={4}>
+                        <Heading size="sm" color={darkMode ? 'purple.400' : 'purple.600'}>
+                          App Config YAML
+                        </Heading>
+                        <Clipboard textToCopy={appConfigYaml} darkMode={darkMode} />
+                      </HStack>
                       <Box
                         borderRadius="md"
                         overflow="auto"

--- a/src/components/Clipboard.tsx
+++ b/src/components/Clipboard.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { IconButton, Tooltip } from "@chakra-ui/react";
+import { IconButton } from "@chakra-ui/react";
 import { Clipboard as ClipboardIcon, Check } from "lucide-react";
 
 interface ClipboardProps {
@@ -8,27 +8,24 @@ interface ClipboardProps {
 }
 
 export const Clipboard = ({ textToCopy, darkMode }: ClipboardProps) => {
-  const [copied, setCopied] = useState(false);
+  const [hasCopied, setHasCopied] = useState(false);
 
-  const handleCopy = () => {
-    navigator.clipboard.writeText(textToCopy).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    });
+  const onCopy = () => {
+    navigator.clipboard.writeText(textToCopy);
+    setHasCopied(true);
+    setTimeout(() => setHasCopied(false), 2000);
   };
 
   return (
-    <Tooltip label={copied ? "Copied!" : "Copy to clipboard"} placement="top">
-      <IconButton
-        aria-label="Copy to clipboard"
-        onClick={handleCopy}
-        variant="ghost"
-        size="sm"
-        color={copied ? "green.400" : darkMode ? "gray.400" : "gray.600"}
-        _hover={{ bg: darkMode ? "gray.700" : "gray.200" }}
-      >
-        {copied ? <Check size={16} /> : <ClipboardIcon size={16} />}
-      </IconButton>
-    </Tooltip>
+    <IconButton
+      aria-label={hasCopied ? "Copied!" : "Copy to clipboard"}
+      onClick={onCopy}
+      variant="ghost"
+      size="sm"
+      color={hasCopied ? "green.400" : darkMode ? "gray.400" : "gray.600"}
+      _hover={{ bg: darkMode ? "gray.700" : "gray.200" }}
+    >
+      {hasCopied ? <Check size={16} /> : <ClipboardIcon size={16} />}
+    </IconButton>
   );
 };

--- a/src/components/Clipboard.tsx
+++ b/src/components/Clipboard.tsx
@@ -1,0 +1,34 @@
+import { useState } from "react";
+import { IconButton, Tooltip } from "@chakra-ui/react";
+import { Clipboard as ClipboardIcon, Check } from "lucide-react";
+
+interface ClipboardProps {
+  textToCopy: string;
+  darkMode: boolean;
+}
+
+export const Clipboard = ({ textToCopy, darkMode }: ClipboardProps) => {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(textToCopy).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  };
+
+  return (
+    <Tooltip label={copied ? "Copied!" : "Copy to clipboard"} placement="top">
+      <IconButton
+        aria-label="Copy to clipboard"
+        onClick={handleCopy}
+        variant="ghost"
+        size="sm"
+        color={copied ? "green.400" : darkMode ? "gray.400" : "gray.600"}
+        _hover={{ bg: darkMode ? "gray.700" : "gray.200" }}
+      >
+        {copied ? <Check size={16} /> : <ClipboardIcon size={16} />}
+      </IconButton>
+    </Tooltip>
+  );
+};

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -7,18 +7,7 @@ vi.mock('@monaco-editor/react', () => ({
   default: vi.fn(() => React.createElement('div', { 'data-testid': 'monaco-editor' }, 'Monaco Editor Mock')),
 }));
 
-// Mock lucide-react icons
-vi.mock('lucide-react', () => ({
-  Sun: vi.fn(() => React.createElement('div', { 'data-testid': 'sun-icon' }, 'Sun Icon')),
-  Moon: vi.fn(() => React.createElement('div', { 'data-testid': 'moon-icon' }, 'Moon Icon')),
-  Menu: vi.fn(() => React.createElement('div', { 'data-testid': 'menu-icon' }, 'Menu Icon')),
-  ChevronRight: vi.fn(() => React.createElement('div', { 'data-testid': 'chevron-right-icon' }, 'ChevronRight Icon')),
-  Trash2: vi.fn(() => React.createElement('div', { 'data-testid': 'trash-icon' }, 'Trash2 Icon')),
-  Plus: vi.fn(() => React.createElement('div', { 'data-testid': 'plus-icon' }, 'Plus Icon')),
-  X: vi.fn(() => React.createElement('div', { 'data-testid': 'x-icon' }, 'X Icon')),
-  Settings: vi.fn(() => React.createElement('div', { 'data-testid': 'settings-icon' }, 'Settings Icon')),
-  Check: vi.fn(() => React.createElement('div', { 'data-testid': 'check-icon' }, 'Check Icon')),
-}));
+vi.mock('lucide-react');
 
 // Mock window.matchMedia
 Object.defineProperty(window, 'matchMedia', {


### PR DESCRIPTION
Adds a button to the GraphQL schema and App Config YAML views to copy the content to the clipboard.